### PR TITLE
Fixed several typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ tools/yast-check-lcn-import.sh can be used to check consistency
 - Jenkins CI build is triggered
 - Upon success, the .pot files are generated in Jenkins
 - Resulting .pot files are automatically checked into WebLate by Jenkins
-- WebLate integrates new or changed messages into the .po.xy files
+- WebLate integrates new or changed messages into the .xy.po files
 
 
 ## openSUSE Products (Tumbleweed, Leap)
 
-- Community translators translate the changed messages in the .po.xy files
+- Community translators translate the changed messages in the .xy.po files
 - Community translators check their changes in to WebLate
 - Weblate pushes changes to GitHub
-- .mo.xy files are generated
+- .xy.mo files are generated
 - yast-trans-xy packages are rebuilt
 - Update repos and installation ISOs are rebuilt with those new yast-trans-xy
   packages
@@ -38,10 +38,10 @@ tools/yast-check-lcn-import.sh can be used to check consistency
 
 - .pot files are checked into the translation SVN (manual step)
 - Translation coordinator pulls pot files from SVN to a proprietary tool
-- Professional translators translate the changed messages in the .po.xy files
+- Professional translators translate the changed messages in the .xy.po files
 - Translators check their changes into proprierary tool
-- Translatoion coordinators check their changes into SVN
-- .mo.xy files are generated (triggered manually (?))
+- Translation coordinators check their changes into SVN
+- .xy.mo files are generated (triggered manually (?))
 - yast-trans-xy packages are rebuilt
 - Update repos and installation ISOs are rebuilt with those new yast-trans-xy
   packages


### PR DESCRIPTION
Message catalogs have lang code first and file extention in the end (like text.es.po or index.ru.mo)