### PR TITLE
Ignore y2makepot errors in the Jenkins script

### DIFF
--- a/tools/update-tool-cron.sh
+++ b/tools/update-tool-cron.sh
@@ -141,11 +141,12 @@ for DOMAIN in * ; do
     popd
 done
 
-if [ "$FAILED_PACKAGES" != "" ]; then
-  echo "WARNING: y2makepot failed for these packages: $FAILED_PACKAGES"
+if [ -n "$FAILED_PACKAGES" ]; then
+  echo "ERROR: y2makepot failed for these packages: $FAILED_PACKAGES"
+  exit 1
 fi
 
-if [ "$ERR" != "" ]; then
+if [ -n "$ERR" ]; then
     echo "$ERR errors occurred. Check *.err files in the ./po/ subdirectory"
     exit $ERR
 else

--- a/tools/update-tool-cron.sh
+++ b/tools/update-tool-cron.sh
@@ -11,6 +11,8 @@ fi
 WORKDIR=$PWD
 TRANDIR=$WORKDIR/translations/po
 TRANPARTS=$WORKDIR/translations/po-parts
+# remember failed packages and report them at the end
+FAILED_PACKAGES=""
 
 # Check for y2makepot:
 if ! Y2MAKEPOT=`command -v y2makepot`; then
@@ -29,7 +31,7 @@ function make_pot {
 
     rm -f *.pot
     # ignore errors, stopping here would skip the other packages
-    $Y2MAKEPOT || true
+    $Y2MAKEPOT || FAILED_PACKAGES="$FAILED_PACKAGES $MODULE_DIR"
 
     for POT in *.pot ; do
 	local DOMAIN=${POT%.pot}
@@ -138,6 +140,10 @@ for DOMAIN in * ; do
     git commit -m "New POT for text domain '$DOMAIN'."
     popd
 done
+
+if [ "$FAILED_PACKAGES" != "" ]; then
+  echo "WARNING: y2makepot failed for these packages: $FAILED_PACKAGES"
+fi
 
 if [ "$ERR" != "" ]; then
     echo "$ERR errors occurred. Check *.err files in the ./po/ subdirectory"

--- a/tools/update-tool-cron.sh
+++ b/tools/update-tool-cron.sh
@@ -28,7 +28,8 @@ function make_pot {
     pushd $MODULE_DIR
 
     rm -f *.pot
-    $Y2MAKEPOT
+    # ignore errors, stopping here would skip the other packages
+    $Y2MAKEPOT || true
 
     for POT in *.pot ; do
 	local DOMAIN=${POT%.pot}


### PR DESCRIPTION
A bug in one package would stop the whole script and prevent from sending the changes in the other packages.

- This is related to [this change in the `y2makepot`](https://github.com/yast/yast-devtools/pull/127) which changed a warning to an error
- See a failure at https://ci.suse.de/view/YaST/job/yast-POT-updater/506/console