### PR TITLE
Installation Proposal BiDi fix (bsc#1089846)

### DIFF
--- a/po/installation/ar.po
+++ b/po/installation/ar.po
@@ -14,7 +14,7 @@ msgstr ""
 "Project-Id-Version: installation\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-04-20 02:28+0000\n"
-"PO-Revision-Date: 2018-04-18 13:15+0000\n"
+"PO-Revision-Date: 2018-04-23 13:29+0200\n"
 "Last-Translator: George Yacoub <george.yacoub@arabize.com>\n"
 "Language-Team: Arabic <https://l10n.opensuse.org/projects/yast-installation/"
 "master/ar/>\n"
@@ -66,18 +66,18 @@ msgstr "منافذ VNC ستكون مفتوحة (<a href=\"%s\">حظر</a>)"
 
 #: src/lib/y2firewall/clients/proposal.rb:133
 msgid "VNC ports will be blocked (<a href=\"%s\">open</a>)"
-msgstr "VNC سيكون مغلق (<a href=\"%s\">فتح</a>)"
+msgstr "‏VNC سيكون مغلق (<a href=\"%s\">فتح</a>)"
 
 #. Returns the SSH-port part of the firewall proposal description
 #. Returns nil if this part should be skipped
 #. @return [String] proposal html text
 #: src/lib/y2firewall/clients/proposal.rb:144
 msgid "SSH port will be open (<a href=\"%s\">block</a>)"
-msgstr "SSH سيتم فتحه (<a href=\"%s\">أغلق</a>)"
+msgstr "‏SSH سيتم فتحه (<a href=\"%s\">أغلق</a>)"
 
 #: src/lib/y2firewall/clients/proposal.rb:146
 msgid "SSH port will be blocked (<a href=\"%s\">open</a>)"
-msgstr "SSH سيتم منعه (<a href=\"%s\">فتح</a>)"
+msgstr "‏SSH سيتم منعه (<a href=\"%s\">فتح</a>)"
 
 #. Returns the Firewalld service part of the firewall proposal description
 #. @return [String] proposal html text


### PR DESCRIPTION
Fixed the "SSH" BiDi text direction in the installation proposal
https://bugzilla.suse.com/show_bug.cgi?id=1089846

Actually this is a workaround, it should not be necessary if there was a `<div dir='rtl'>...</div>` parent but this will be quicker.