### PR TITLE
Add sap-installation-wizard textdomain

### DIFF
--- a/po/sap-installation-wizard/sap-installation-wizard.pot
+++ b/po/sap-installation-wizard/sap-installation-wizard.pot
@@ -1,0 +1,608 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR SuSE Linux Products GmbH, Nuernberg
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-05-08 14:53+0000\n"
+"PO-Revision-Date: 2018-05-08 14:53+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Check if hostname -f is set
+#: src/clients/firstboot_inst_sap.rb:33
+msgid "The fully qualified hostname (FQHN) could not be detected."
+msgstr ""
+
+#: src/clients/firstboot_inst_sap.rb:34
+msgid ""
+"Do you want to return to network setup or abort the SAP product installation a"
+"nd start the installed system?"
+msgstr ""
+
+#: src/clients/firstboot_inst_sap.rb:35
+msgid "Return to Network Setup"
+msgstr ""
+
+#: src/clients/firstboot_inst_sap.rb:36
+msgid "Abort"
+msgstr ""
+
+#: src/clients/firstboot_inst_sap.rb:44
+msgid "Product Installation Mode"
+msgstr ""
+
+#: src/clients/firstboot_inst_sap.rb:45
+msgid "The standard installation of the Operating System has settled."
+msgstr ""
+
+#: src/clients/firstboot_inst_sap.rb:46
+msgid "Now you can start the SAP Product Installation"
+msgstr ""
+
+#. MAY BE TODO set the default value
+#: src/clients/inst_sap-start.rb:44
+msgid "Choose Operating System Edition"
+msgstr ""
+
+#: src/clients/inst_sap-start.rb:45
+msgid ""
+"<p><b>Select operating system edition</b></p><p>If you wish to proceed with in"
+"stalling SAP softwares right after installing the operating system, tick the c"
+"heckbox \"Launch SAP product installation wizard right after operating system i"
+"s installed\".</p>"
+msgstr ""
+
+#: src/clients/inst_sap-start.rb:56
+msgid ""
+"Launch SAP product installation wizard right after operating system is install"
+"ed"
+msgstr ""
+
+#: src/clients/inst_sap-start.rb:63
+msgid "Enable Remote Desktop Protocol (RDP) Service and open port in Firewall"
+msgstr ""
+
+#. the command line description map
+#: src/clients/sap-installation-wizard.rb:44
+msgid "YAST Module to Install SAP Applications on SLES for SAP Applications."
+msgstr ""
+
+#. "initialize" => fun_ref(SAPInst.method(:Read), "boolean ()"),
+#. "finish"     => fun_ref(SAPInst.method(:Write),"boolean ()"),
+#: src/clients/sap-installation-wizard.rb:51
+msgid "Create HANA Partitionint."
+msgstr ""
+
+#. Return a readable text summary.
+#: src/clients/sap-installation-wizard_auto.rb:68
+msgid "SAP Product Automatic Installation."
+msgstr ""
+
+#. the command line description map
+#: src/clients/sap-media.rb:42
+msgid "YAST module to prepare SAP installation envinroment."
+msgstr ""
+
+#. TRANSLATORS: help text
+#: src/clients/sap_proposal.rb:39
+msgid ""
+"<p>Use <b>Start SAP Product Setup after Installation</b> if you want the SAP I"
+"nstallation Wizard to start after the base system was installed.</p>"
+msgstr ""
+
+#: src/clients/sap_proposal.rb:61
+msgid "SAP product installation"
+msgstr ""
+
+#: src/clients/sap_proposal.rb:63
+msgid "Start SAP Installation Wizard at the end of installation?"
+msgstr ""
+
+#: src/clients/sap_proposal.rb:68
+msgid "Create SAP file systems and start SAP product installation."
+msgstr ""
+
+#: src/clients/sap_proposal.rb:75
+msgid "Only create SAP Business One file systems, do not install SAP products now."
+msgstr ""
+
+#: src/clients/sap_proposal.rb:82
+msgid "Do not start SAP Product installation. Proceed to OS login."
+msgstr ""
+
+#. this is a heading
+#: src/clients/sap_proposal.rb:109
+msgid "Start SAP Installation Wizard at the End of Installation"
+msgstr ""
+
+#. this is a menu entry
+#: src/clients/sap_proposal.rb:111
+msgid "Start SAP Installation &Wizard at the End of Installation"
+msgstr ""
+
+#. TRANSLATORS: Installation overview
+#. IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+#: src/clients/sap_proposal.rb:130
+msgid "<a href=\"%1\">Create SAP file systems and start SAP product installation.</a>"
+msgstr ""
+
+#. TRANSLATORS: Installation overview
+#. IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+#: src/clients/sap_proposal.rb:139
+msgid ""
+"<a href=\"%1\">Only create SAP Business One file systems, do not install SAP pro"
+"ducts now.</a>"
+msgstr ""
+
+#. TRANSLATORS: Installation overview
+#. IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+#: src/clients/sap_proposal.rb:148
+msgid "<a href=\"%1\">Do not start SAP Product installation. Proceed to OS login.</a>"
+msgstr ""
+
+#. Return a ruby symbol that directs Yast Wizard workflow (for example :next, :back, :abort)
+#: src/lib/sap/add_repo_dialog.rb:67
+msgid "Do you have more software repositories to add?"
+msgstr ""
+
+#: src/lib/sap/add_repo_dialog.rb:85
+msgid "Additional software repositories for your SAP installation"
+msgstr ""
+
+#: src/lib/sap/add_repo_dialog.rb:87
+msgid "Do you use additional software repositories, such as 3rd-party SAP add-ons?"
+msgstr ""
+
+#: src/lib/sap/add_repo_dialog.rb:88
+msgid "Feel free to add them now. Otherwise, click \"Next\" to continue."
+msgstr ""
+
+#: src/lib/sap/add_repo_dialog.rb:89
+msgid "Add new software repositories"
+msgstr ""
+
+#: src/lib/sap/add_repo_dialog.rb:91
+msgid ""
+"You now have an opportunity to add software repositories, for example: reposit"
+"ores for SAP partner solutions.\n"
+"The step is completely optional, simply click \"Next\" if you do not use any add"
+"itional repositories."
+msgstr ""
+
+#. Hash for design the dialogs
+#. Help text for the fututre. This will be available only in SP1
+#. '<p><b>' + _("SUSE HA for SAP Simple Stack") + '</p></b>' +
+#. _("With this installation mode the <b>SUSE-HA for SAP Simple Stack</b> can be installed and configured.") +
+#. Hash for design the dialogs
+#. Help text for the fututre. This will be available only in SP1
+#. '<p><b>' + _("SUSE HA for SAP Simple Stack") + '</p></b>' +
+#. _("With this installation mode the <b>SUSE-HA for SAP Simple Stack</b> can be installed and configured.") +
+#: src/lib/sap/dialogs.rb:82 src/modules/SAPMedia.rb:45
+msgid "<p>Enter location of SAP installation master medium to prepare it for use.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:83 src/modules/SAPMedia.rb:47
+msgid "Prepare the SAP installation master medium"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:86 src/modules/SAPMedia.rb:50
+msgid "<p>Enter the location of your SAP medium.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:87 src/modules/SAPMedia.rb:51
+msgid ""
+"Location of the SAP product medium (e.g. SAP kernel, database, and database ex"
+"ports)"
+msgstr ""
+
+#. Some parameter of the actual selected product
+#: src/lib/sap/dialogs.rb:90 src/modules/SAPProduct.rb:33
+msgid "<p>Choose SAP product installation and back-end database.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:91 src/lib/sap/dialogs.rb:233
+#: src/modules/SAPProduct.rb:34 src/modules/SAPProduct.rb:143
+msgid "SAP Standard System"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:92 src/modules/SAPProduct.rb:35
+msgid ""
+"<p>Installation of a SAP NetWeaver system with all servers on the same host.</"
+"p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:93 src/lib/sap/dialogs.rb:237
+#: src/modules/SAPProduct.rb:36 src/modules/SAPProduct.rb:147
+msgid "SAP Standalone Engines"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:94 src/modules/SAPProduct.rb:37
+msgid "<p>Standalone engines are SAP Trex, SAP Gateway, and Web Dispatcher.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:95 src/lib/sap/dialogs.rb:234
+#: src/modules/SAPProduct.rb:38 src/modules/SAPProduct.rb:144
+msgid "Distributed System"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:96 src/modules/SAPProduct.rb:39
+msgid ""
+"Installation of SAP NetWeaver with the servers distributed on separate hosts.<"
+"/p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:97 src/modules/SAPProduct.rb:40
+msgid "High-Availability System"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:98 src/modules/SAPProduct.rb:41
+msgid "Installation of SAP NetWeaver in a high-availability setup.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:99 src/lib/sap/dialogs.rb:238
+#: src/modules/SAPProduct.rb:42 src/modules/SAPProduct.rb:148
+msgid "System Rename"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:100 src/modules/SAPProduct.rb:43
+msgid ""
+"Change the SAP system ID, database ID, instance number, or host name of a SAP "
+"system.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:101 src/modules/SAPProduct.rb:44
+msgid "Choose the Installation Type!"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:104 src/modules/SAPProduct.rb:47
+msgid "<p>Please choose the SAP product you wish to install.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:105 src/modules/SAPProduct.rb:48
+msgid "Choose a Product"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:108 src/modules/SAPMedia.rb:54
+msgid ""
+"<p>Enter the location of your database medium. The database type is determined"
+" automatically.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:109 src/modules/SAPMedia.rb:55
+msgid "Location of the Database Medium"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:112 src/modules/SAPMedia.rb:58
+msgid ""
+"<p>Enter the path to a medium with a SAP Unicode Kernel if you want to perform"
+" an ABAP-based installation or to a SAP Java medium to perform a JAVA-based in"
+"stallation.</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:113 src/modules/SAPMedia.rb:59
+msgid "Path to a Kernel or Java Medium"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:116 src/modules/SAPMedia.rb:62
+msgid ""
+"<p>Enter the path to a 3rd party medium which you want to copy to the machine."
+"</p>"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:117 src/modules/SAPMedia.rb:63
+msgid "3rd Party Medium"
+msgstr ""
+
+#. is_instmaster gives back a key-value pair to split for the BO workflow
+#. KEY: SAPINST, BOBJ, HANA, B1
+#. VALUE: complete path to the instmaster directory incl. sourceDir
+#. is_instmaster gives back a key-value pair to split for the BO workflow
+#. KEY: SAPINST, BOBJ, HANA, B1
+#. VALUE: complete path to the instmaster directory incl. sourceDir
+#: src/lib/sap/dialogs.rb:166 src/modules/SAPMedia.rb:428
+msgid ""
+"The location has expired or does not point to an SAP installation master.\n"
+"Please check your input."
+msgstr ""
+
+#. Reset the selected installation type and DB
+#. Reset the the selected product specific parameter
+#: src/lib/sap/dialogs.rb:230 src/modules/SAPProduct.rb:140
+msgid "Installation Type"
+msgstr ""
+
+#. RadioButton( Id("SUSE-HA-ST"),  Opt(:notify, :hstretch), _("SUSE HA for SAP Simple Stack"), false),
+#. RadioButton( Id("SUSE-HA-ST"),  Opt(:notify, :hstretch), _("SUSE HA for SAP Simple Stack"), false),
+#: src/lib/sap/dialogs.rb:236 src/modules/SAPProduct.rb:146
+msgid "SAP High-Availability System"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:243 src/modules/SAPProduct.rb:153
+msgid "Back-end Databases"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:246 src/modules/SAPProduct.rb:156
+msgid "SAP MaxDB"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:247 src/modules/SAPProduct.rb:157
+msgid "SAP HANA"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:248 src/modules/SAPProduct.rb:158
+msgid "SAP ASE"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:249 src/modules/SAPProduct.rb:159
+msgid "IBM DB2"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:250 src/modules/SAPProduct.rb:160
+msgid "Oracle"
+msgstr ""
+
+#. Does not exists at the time
+#. UI.ChangeWidget(Id("SUSE-HA-ST"),  :Enabled, false)
+#: src/lib/sap/dialogs.rb:279 src/modules/SAPProduct.rb:203
+msgid "Please choose an SAP installation type."
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:284 src/modules/SAPProduct.rb:208
+msgid "Please choose a back-end database."
+msgstr ""
+
+#. ############################################################
+#.
+#. SelectNWProduct
+#.
+#. ###########################################################
+#. ############################################################
+#.
+#. SelectNWProduct
+#.
+#. ###########################################################
+#: src/lib/sap/dialogs.rb:316 src/modules/SAPProduct.rb:239
+msgid "The medium does not contain SAP installation data."
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:330 src/modules/SAPProduct.rb:253
+msgid ""
+"Your SAP installation master supports the following products.\n"
+"Please choose the product you wish to install:"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:345 src/modules/SAPProduct.rb:268
+msgid "Select a product!"
+msgstr ""
+
+#. Skip the dialog all together if SAP_CD is already mounted from network location
+#. There is no chance for user to copy new mediums to the location
+#. Skip the dialog all together if SAP_CD is already mounted from network location
+#. There is no chance for user to copy new mediums to the location
+#: src/lib/sap/dialogs.rb:395 src/modules/SAPMedia.rb:486
+#: src/modules/SAPMedia.rb:497
+msgid "Are there more SAP product mediums to be prepared?"
+msgstr ""
+
+#. ############################################################
+#.
+#. Ask for 3rd-Party/ Supplement dialog (includes a product.xml)
+#.
+#. ###########################################################
+#. ############################################################
+#.
+#. Ask for 3rd-Party/ Supplement dialog (includes a product.xml)
+#.
+#. ###########################################################
+#: src/lib/sap/dialogs.rb:408 src/modules/SAPMedia.rb:518
+msgid "Do you use a Supplement/3rd-Party SAP software medium?"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:420 src/modules/SAPMedia.rb:530
+msgid "Are there more supplementary mediums to be prepared?"
+msgstr ""
+
+#. Display the empty dialog before running external SAP installer program
+#. Display the empty dialog before running external SAP installer program
+#: src/lib/sap/dialogs.rb:437 src/modules/SAPProduct.rb:322
+msgid "Collecting installation profile for SAP product"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:439 src/modules/SAPProduct.rb:324
+msgid "Please follow the on-screen instructions of SAP installer (external program)."
+msgstr ""
+
+#. TODO VIRTHOST MUST BE CONFIGURED HERE NOT IN THE SCRIPT
+#. Replace kernel base
+#: src/lib/sap/dialogs.rb:501 src/modules/SAPProduct.rb:402
+msgid ""
+"Installation profile is ready.\n"
+"Are there more SAP products to be prepared for installation?"
+msgstr ""
+
+#. This is not a real SAP medium.
+#. This is not a real SAP medium.
+#: src/lib/sap/dialogs.rb:573 src/modules/SAPMedia.rb:1391
+msgid "The location does not contain SAP installation data."
+msgstr ""
+
+#. List existing product installation mediums (excluding installation master)
+#. Find the already-prepared mediums
+#. List existing product installation mediums (excluding installation master)
+#. Find the already-prepared mediums
+#: src/lib/sap/dialogs.rb:608 src/lib/sap/dialogs.rb:665
+#: src/modules/SAPMedia.rb:1429 src/modules/SAPMedia.rb:1484
+msgid "Ready for use:"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:613 src/modules/SAPMedia.rb:1432
+msgid "Copy a medium"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:618 src/modules/SAPMedia.rb:1437
+msgid "Prepare SAP installation medium (such as SAP kernel, database and exports)"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:623 src/lib/sap/dialogs.rb:674
+msgid ""
+"Link to the installation medium, without copying its content to local location"
+"."
+msgstr ""
+
+#. If SAP_CD is mounted from network location, do not allow empty selection
+#. If SAP_CD is mounted from network location, do not allow empty selection
+#: src/lib/sap/dialogs.rb:633 src/modules/SAPMedia.rb:1452
+msgid "Ready for use from:  "
+msgstr ""
+
+#. Otherwise, allow user to enter new installation master
+#. Otherwise, allow user to enter new installation master
+#: src/lib/sap/dialogs.rb:635 src/lib/sap/dialogs.rb:641
+#: src/modules/SAPMedia.rb:1454 src/modules/SAPMedia.rb:1460
+msgid "Choose an installation master"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:649 src/modules/SAPMedia.rb:1468
+msgid "Prepare SAP installation master"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:652 src/modules/SAPMedia.rb:1471
+msgid ""
+"Collect installation profiles for SAP products but do not execute installation"
+"."
+msgstr ""
+
+#. link & export options are not applicable if SAP_CD is mounted from network location
+#: src/lib/sap/dialogs.rb:656
+msgid ""
+"Link to the installation master, without copying its content to local location"
+" (SAP NetWeaver only)."
+msgstr ""
+
+#. Left(CheckBox(Id(:link),_("Link to the installation master, without copying its content to local location (SAP NetWeaver only)."), false)),
+#: src/lib/sap/dialogs.rb:657 src/modules/SAPMedia.rb:1476
+msgid "Serve all installation mediums (including master) to local network via NFS."
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:670 src/modules/SAPMedia.rb:1489
+msgid "Prepare SAP supplementary medium"
+msgstr ""
+
+#. content_advanced_ops = VBox(
+#. Left(CheckBox(Id(:link),_("Link to the installation medium, without copying its content to local location."),false))
+#. )
+#: src/lib/sap/dialogs.rb:684 src/modules/SAPMedia.rb:1503
+msgid "Skip copying of medium"
+msgstr ""
+
+#. Render the wizard
+#. Render the wizard
+#: src/lib/sap/dialogs.rb:696 src/modules/SAPMedia.rb:1524
+msgid "Advanced Options"
+msgstr ""
+
+#: src/lib/sap/dialogs.rb:701 src/modules/SAPMedia.rb:1530
+msgid "SAP Installation Wizard"
+msgstr ""
+
+#. Break the loop for a chosen installation master, without executing check_media
+#. Break the loop for a chosen installation master, without executing check_media
+#: src/lib/sap/dialogs.rb:781 src/modules/SAPMedia.rb:1634
+msgid "Failed to mount the location: "
+msgstr ""
+
+#: src/modules/SAPMedia.rb:46
+msgid ""
+"Valid SAP installation master media are: <b>SWPM, TREX, HANA and Business One "
+"media."
+msgstr ""
+
+#. User has three choices: do nothing, ignore, or run it at end of the wizard workflow
+#: src/modules/SAPMedia.rb:176
+msgid "Pending installation from previous wizard run"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:177
+msgid ""
+"Installation profile was previously collected for the following product, howev"
+"er it has not been installed yet:\n"
+"\n"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:179
+msgid ""
+"Would you like to delete it, install the product at the last wizard step, or i"
+"gnore it?"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:180
+msgid "Delete"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:180
+msgid "Install"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:180
+msgid "Ignore and do nothing"
+msgstr ""
+
+#. Now we start the product installation
+#. pid = 0
+#: src/modules/SAPMedia.rb:319 src/modules/SAPProduct.rb:462
+msgid "SAP Product Installation"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:356
+msgid "Do you want to install another product?"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:491
+msgid "The selected medium '%1' was already copied."
+msgstr ""
+
+#. autoyast has read the autoyast configuration file but something went wrong
+#: src/modules/SAPMedia.rb:584
+msgid ""
+"The XML parser reported an error while parsing the autoyast profile. The error"
+" message is:\n"
+msgstr ""
+
+#. Display a dialog to let user choose a server
+#: src/modules/SAPMedia.rb:1103
+msgid "SLES4SAP installation servers are detected"
+msgstr ""
+
+#. Expose NFS service via SLP
+#. The SLP service description lists all medium names
+#: src/modules/SAPMedia.rb:1159
+msgid ""
+"Failed to start SLP server. SAP mediums will not be discovered by other comput"
+"ers."
+msgstr ""
+
+#. ***********************************
+#. select the usb media we want use
+#: src/modules/SAPMedia.rb:1308
+msgid "<p>Please enter the right USB device.</p>"
+msgstr ""
+
+#: src/modules/SAPMedia.rb:1318
+msgid "SAP Installation Wizard - Step 1"
+msgstr ""
+
+#. FATE
+#: src/modules/SAPProduct.rb:537
+msgid ""
+"The Installation of Oracle Databas with SAP Installation Wizard is not support"
+"ed."
+msgstr ""


### PR DESCRIPTION
Manually adding the sap-installation-wizard textdomain. We need to find a better long-term solution, but for the time being, this should be good enough.