### PR TITLE
Do not translate yast/y2status

### DIFF
--- a/po/SKIP_PROJECTS
+++ b/po/SKIP_PROJECTS
@@ -1,1 +1,2 @@
 storage
+y2status


### PR DESCRIPTION
It's a [YaST Status Overview dashboard](https://github.com/yast/y2status) and it does not need to be translated. Skipping it fixes https://bugzilla.suse.com/show_bug.cgi?id=1194804