### PR TITLE
Update control.pot to fix translation bugs

### DIFF
--- a/po/control/control.pot
+++ b/po/control/control.pot
@@ -27,8 +27,7 @@ msgid ""
 "</p>\n"
 "<p>\n"
 "Please visit us at http://www.suse.com/.\n"
-"</p>\n"
-"        "
+"</p>"
 msgstr ""
 
 #: control/control.Kubic.glade.translations.glade:14
@@ -338,8 +337,7 @@ msgstr ""
 #: package/xfce-changecontrolxml.glade.translations.glade:2
 msgid ""
 "Graphical system with XFCE as desktop environment. Suitable for "
-"Workstations, Desktops and Laptops.\n"
-"          "
+"Workstations, Desktops and Laptops."
 msgstr ""
 
 #: control/control.openSUSE.glade.translations.glade:3
@@ -349,8 +347,7 @@ msgid ""
 "<p>The installation of openSUSE on your machine is complete.\n"
 "After clicking <b>Finish</b>, you can log in to the system.</p>\n"
 "<p>Visit us at %1.</p>\n"
-"<p>Have a lot of fun!<br>Your openSUSE Development Team</p>\n"
-"            "
+"<p>Have a lot of fun!<br>Your openSUSE Development Team</p>"
 msgstr ""
 
 #. TRANSLATORS: a label for a system role
@@ -361,8 +358,7 @@ msgstr ""
 #: control/control.openSUSE.glade.translations.glade:22
 msgid ""
 "Graphical system with KDE Plasma as desktop environment. Suitable for "
-"Workstations, Desktops and Laptops.\n"
-"          "
+"Workstations, Desktops and Laptops."
 msgstr ""
 
 #. TRANSLATORS: a label for a system role
@@ -373,8 +369,7 @@ msgstr ""
 #: control/control.openSUSE.glade.translations.glade:26
 msgid ""
 "Graphical system with GNOME as desktop environment. Suitable for "
-"Workstations, Desktops and Laptops.\n"
-"\t  "
+"Workstations, Desktops and Laptops."
 msgstr ""
 
 #. TRANSLATORS: a label for a system role
@@ -385,8 +380,7 @@ msgstr ""
 #: control/control.openSUSE.glade.translations.glade:30
 msgid ""
 "Graphical system with Xfce as desktop environment. Suitable for "
-"Workstations, Desktops and Laptops.\n"
-"          "
+"Workstations, Desktops and Laptops."
 msgstr ""
 
 #. TRANSLATORS: a label for a system role
@@ -417,8 +411,7 @@ msgstr ""
 #: control/control.openSUSE.glade.translations.glade:40
 msgid ""
 "Like the Server role but uses a read-only root filesystem to provide atomic, "
-"automatic updates of a system without interfering with the running system.\n"
-"          "
+"automatic updates of a system without interfering with the running system."
 msgstr ""
 
 #: control/control.openSUSE.glade.translations.glade:59
@@ -465,7 +458,7 @@ msgstr ""
 #: installation.SLE_HPC.glade.translations.glade:15
 msgid ""
 "• Includes HPC-enabled libraries\n"
-"• Adds compilers and development toolchain\n"
+"• Adds compilers and development toolchain"
 msgstr ""
 
 #: installation.SLE_HPC.glade.translations.glade:24
@@ -617,7 +610,7 @@ msgid ""
 "• Installs client for the Slurm Workload Manager \n"
 "• Does not create a separate home partition\n"
 "• Does not create a local user\n"
-"• Mounts a large scratch partition to /var/tmp\n"
+"• Mounts a large scratch partition to /var/tmp"
 msgstr ""
 
 #. TRANSLATORS: a label for a system role
@@ -631,7 +624,7 @@ msgid ""
 "• Includes HPC-enabled libraries\n"
 "• Disables firewall and kdump services\n"
 "• Installs controller for the Slurm Workload Manager \n"
-"• Mounts a large scratch partition to /var/tmp\n"
+"• Mounts a large scratch partition to /var/tmp"
 msgstr ""
 
 #. TRANSLATORS: a label for a system role


### PR DESCRIPTION

## Problem

*There are some untranslated strings in YaST Control due to XML parser in YaST*

*[Bugzilla link](https://bugzilla.opensuse.org/show_bug.cgi?id=1197965#c7)*


## Solution

*Delete all /n and spaces in the end of msgid strings group (not EACH msgid string)*

