### PR TITLE
Rename the msgid for Ukraine (Kiev) to Ukraine (Kyiv) as the timezone…

### DIFF
--- a/po/timezone_db/af.po
+++ b/po/timezone_db/af.po
@@ -106,7 +106,7 @@ msgstr "Rusland (Kaliningrad)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Oekraïne"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/am.po
+++ b/po/timezone_db/am.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ar.po
+++ b/po/timezone_db/ar.po
@@ -108,7 +108,7 @@ msgstr "روسيا (كالينجراد)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "أوكرانيا (كييف)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ast.po
+++ b/po/timezone_db/ast.po
@@ -118,7 +118,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucraína (Kiev)"
 
 # /usr/lib/YaST2/keyboard_raw.ycp:260
@@ -246,7 +246,7 @@ msgstr "Albania"
 
 #: timezone/src/data/timezone_raw.ycp:83
 #, fuzzy
-#| msgid "Ukraine (Kiev)"
+#| msgid "Ukraine (Kyiv)"
 msgid "Ukraine (Uzhgorod)"
 msgstr "Ucraína (Kiev)"
 

--- a/po/timezone_db/be.po
+++ b/po/timezone_db/be.po
@@ -105,7 +105,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/bg.po
+++ b/po/timezone_db/bg.po
@@ -112,7 +112,7 @@ msgstr "Русия (Калининград)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Украйна (Киев)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/bn.po
+++ b/po/timezone_db/bn.po
@@ -104,7 +104,7 @@ msgstr "রাশিয়া (কালিনিনগ্রাদ)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "ইউক্রেন"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/bs.po
+++ b/po/timezone_db/bs.po
@@ -110,7 +110,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ca.po
+++ b/po/timezone_db/ca.po
@@ -111,7 +111,7 @@ msgstr "Rússia (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucraïna (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/cs.po
+++ b/po/timezone_db/cs.po
@@ -114,7 +114,7 @@ msgstr "Rusko (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina (Kyjev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/cy.po
+++ b/po/timezone_db/cy.po
@@ -110,7 +110,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Wcrain"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/da.po
+++ b/po/timezone_db/da.po
@@ -113,7 +113,7 @@ msgstr "Rusland (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraine (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/de.po
+++ b/po/timezone_db/de.po
@@ -119,7 +119,7 @@ msgstr "Russland (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraine (Kyjiw)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/el.po
+++ b/po/timezone_db/el.po
@@ -120,7 +120,7 @@ msgstr "Ρωσία (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ουκρανία (Κίεβο)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/en_GB.po
+++ b/po/timezone_db/en_GB.po
@@ -108,8 +108,8 @@ msgstr "Russia (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
-msgstr "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
+msgstr "Ukraine (Kyiv)"
 
 #: timezone/src/data/timezone_raw.ycp:51
 msgid "Portugal"

--- a/po/timezone_db/eo.po
+++ b/po/timezone_db/eo.po
@@ -104,7 +104,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/es.po
+++ b/po/timezone_db/es.po
@@ -124,7 +124,7 @@ msgstr "Rusia (Kaliningrado)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucrania (Kiev)"
 
 # /usr/lib/YaST2/keyboard_raw.ycp:260

--- a/po/timezone_db/et.po
+++ b/po/timezone_db/et.po
@@ -111,7 +111,7 @@ msgstr "Venemaa (Kaliningrad)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/eu.po
+++ b/po/timezone_db/eu.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/fa.po
+++ b/po/timezone_db/fa.po
@@ -108,7 +108,7 @@ msgstr "روسیه (کالینینگراد)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "اوکراین (کیو)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/fi.po
+++ b/po/timezone_db/fi.po
@@ -121,7 +121,7 @@ msgstr "Venäjä (Kaliningrad)"
 # UA
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kiova)"
 
 # PT

--- a/po/timezone_db/fr.po
+++ b/po/timezone_db/fr.po
@@ -131,7 +131,7 @@ msgstr "Russie (Kaliningrad)"
 # TLABEL country_2002_08_07_0216__92
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraine (Kiev)"
 
 # TLABEL country_2002_08_07_0216__74

--- a/po/timezone_db/gl.po
+++ b/po/timezone_db/gl.po
@@ -113,7 +113,7 @@ msgstr "Rusia (Kaliningrado)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucraína (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/gu.po
+++ b/po/timezone_db/gu.po
@@ -105,7 +105,7 @@ msgstr " રશિયા (કાલિનિનગ્રાડ)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr " યુક્રેન "
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/he.po
+++ b/po/timezone_db/he.po
@@ -121,7 +121,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "אוקראינה"
 
 # PT

--- a/po/timezone_db/hi.po
+++ b/po/timezone_db/hi.po
@@ -102,7 +102,7 @@ msgstr "रूस (कैलिनिनग्राद)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "यूक्रेन (कीव)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/hr.po
+++ b/po/timezone_db/hr.po
@@ -115,7 +115,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina (Kijev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/hu.po
+++ b/po/timezone_db/hu.po
@@ -118,7 +118,7 @@ msgstr "Oroszország (Kalinyingrád)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajna (Kijev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/id.po
+++ b/po/timezone_db/id.po
@@ -108,7 +108,7 @@ msgstr "Rusia (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/it.po
+++ b/po/timezone_db/it.po
@@ -136,7 +136,7 @@ msgstr "Russia (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucraina (Kiev)"
 
 # #-#-#-#-#  timezone_db.it.po (timezone_db)  #-#-#-#-#

--- a/po/timezone_db/ja.po
+++ b/po/timezone_db/ja.po
@@ -115,7 +115,7 @@ msgstr "ロシア (カリーニングラード)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "ウクライナ (キエフ)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/jv.po
+++ b/po/timezone_db/jv.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ka.po
+++ b/po/timezone_db/ka.po
@@ -107,7 +107,7 @@ msgstr "რუსეთი (კალინინგრადი)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "უკრაინა (კიევი)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/km.po
+++ b/po/timezone_db/km.po
@@ -110,7 +110,7 @@ msgstr "រុស្ស៊ី (កាលីនីនក្រាត)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "អ៊ុយក្រែន (កៀវ)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/kn.po
+++ b/po/timezone_db/kn.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ko.po
+++ b/po/timezone_db/ko.po
@@ -109,7 +109,7 @@ msgstr "러시아(칼리닌그라드)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "우크라이나(키예프)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ku.po
+++ b/po/timezone_db/ku.po
@@ -106,7 +106,7 @@ msgstr "Rûsiya (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraniya (Kiyêv)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/lo.po
+++ b/po/timezone_db/lo.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/lt.po
+++ b/po/timezone_db/lt.po
@@ -108,7 +108,7 @@ msgstr "Rusija (Kaliningradas)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kijevas)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/lv.po
+++ b/po/timezone_db/lv.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/mk.po
+++ b/po/timezone_db/mk.po
@@ -124,7 +124,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Украина"
 
 # PT

--- a/po/timezone_db/mr.po
+++ b/po/timezone_db/mr.po
@@ -104,7 +104,7 @@ msgstr "रशिया (कालीनीनग्राड)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "उक्रेन"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ms.po
+++ b/po/timezone_db/ms.po
@@ -107,7 +107,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraine"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/my.po
+++ b/po/timezone_db/my.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/nb.po
+++ b/po/timezone_db/nb.po
@@ -112,7 +112,7 @@ msgstr "Russland (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/nds.po
+++ b/po/timezone_db/nds.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ne.po
+++ b/po/timezone_db/ne.po
@@ -105,7 +105,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/nl.po
+++ b/po/timezone_db/nl.po
@@ -111,7 +111,7 @@ msgstr "Rusland (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Oekraïne (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/nn.po
+++ b/po/timezone_db/nn.po
@@ -128,7 +128,7 @@ msgstr "Russland (Kaliningrad)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/pa.po
+++ b/po/timezone_db/pa.po
@@ -110,7 +110,7 @@ msgstr "ਰੂਸ (ਕਾਲਿੰਨਗਾਰਡ)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "ਯੂਕਰੇਨ (ਕਿਈਵ)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/pl.po
+++ b/po/timezone_db/pl.po
@@ -107,7 +107,7 @@ msgstr "Rosja (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kijów)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ps.po
+++ b/po/timezone_db/ps.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/pt.po
+++ b/po/timezone_db/pt.po
@@ -114,7 +114,7 @@ msgstr "Rússia (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucrânia (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/pt_BR.po
+++ b/po/timezone_db/pt_BR.po
@@ -113,7 +113,7 @@ msgstr "Rússia (Kaliningrado)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucrânia (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ro.po
+++ b/po/timezone_db/ro.po
@@ -120,7 +120,7 @@ msgstr "Rusia (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ucraina (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ru.po
+++ b/po/timezone_db/ru.po
@@ -116,7 +116,7 @@ msgstr "Россия (Калининград)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Украина (Киев)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/si.po
+++ b/po/timezone_db/si.po
@@ -107,7 +107,7 @@ msgstr "රුසියාව"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "යුක්රේනය"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sk.po
+++ b/po/timezone_db/sk.po
@@ -105,7 +105,7 @@ msgstr "Rusko (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sl.po
+++ b/po/timezone_db/sl.po
@@ -114,7 +114,7 @@ msgstr "Rusija (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina (Kijev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sq.po
+++ b/po/timezone_db/sq.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sr.po
+++ b/po/timezone_db/sr.po
@@ -112,7 +112,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sr@latin.po
+++ b/po/timezone_db/sr@latin.po
@@ -107,7 +107,7 @@ msgstr ""
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
 #| msgid "Ukraine"
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrajina"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sv.po
+++ b/po/timezone_db/sv.po
@@ -112,7 +112,7 @@ msgstr "Ryssland (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/sw.po
+++ b/po/timezone_db/sw.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/ta.po
+++ b/po/timezone_db/ta.po
@@ -104,7 +104,7 @@ msgstr "ரஷ்யா (கலினின்கிரேடு)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "உக்ரைன்"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/tg.po
+++ b/po/timezone_db/tg.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/th.po
+++ b/po/timezone_db/th.po
@@ -105,7 +105,7 @@ msgstr "รัสเซีย (เลนินกราด)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "ยูเครน (เคียฟ)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/timezone_db.pot
+++ b/po/timezone_db/timezone_db.pot
@@ -105,7 +105,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/tk.po
+++ b/po/timezone_db/tk.po
@@ -119,7 +119,7 @@ msgstr ""
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraina"
 
 # name for PRT

--- a/po/timezone_db/tr.po
+++ b/po/timezone_db/tr.po
@@ -120,7 +120,7 @@ msgstr "Rusya (Kaliningrad)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukrayna"
 
 # /usr/lib/YaST2/keyboard_raw.ycp:260

--- a/po/timezone_db/tzm.po
+++ b/po/timezone_db/tzm.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/uk.po
+++ b/po/timezone_db/uk.po
@@ -113,7 +113,7 @@ msgstr "Росія (Калінінград)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Україна (Київ)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/vi.po
+++ b/po/timezone_db/vi.po
@@ -105,7 +105,7 @@ msgstr ""
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr ""
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/wa.po
+++ b/po/timezone_db/wa.po
@@ -111,7 +111,7 @@ msgstr "Rûsseye (Kaliningrad)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Oucrinne (Kiev)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/xh.po
+++ b/po/timezone_db/xh.po
@@ -106,7 +106,7 @@ msgstr "iRashiya (Kaliningrad)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "i-Ukraine"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/zh_CN.po
+++ b/po/timezone_db/zh_CN.po
@@ -112,7 +112,7 @@ msgstr "俄罗斯（加里宁格勒）"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "乌克兰（基辅）"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/zh_TW.po
+++ b/po/timezone_db/zh_TW.po
@@ -108,7 +108,7 @@ msgstr "俄羅斯 (加里寧格勒)"
 
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "烏克蘭 (基輔)"
 
 #: timezone/src/data/timezone_raw.ycp:51

--- a/po/timezone_db/zu.po
+++ b/po/timezone_db/zu.po
@@ -106,7 +106,7 @@ msgstr "Russia (Kaliningrad)"
 #. time zone
 #: timezone/src/data/timezone_raw.ycp:50
 #, fuzzy
-msgid "Ukraine (Kiev)"
+msgid "Ukraine (Kyiv)"
 msgstr "Ukraine"
 
 #: timezone/src/data/timezone_raw.ycp:51


### PR DESCRIPTION
… was renamed by ICANN

Source: https://mm.icann.org/pipermail/tz-announce/2022-August/000071.html

## Problem

The Ukraine (Kiev) timezone was renamed to Ukraine (Kyiv) by ICANN in timezone 2022b. Since the translations are not affected by this change, this PR changes only the msgid (as that is what will be translated) and the msgstr for en_GB only (which is the only case where the translation changes), the rest of the translation's msgstr are left untouched.

- [*Bugzilla link*](https://bugzilla.suse.com/show_bug.cgi?id=1224387)
- [*Links to other related pull requests*](https://github.com/yast/yast-country/pull/323)